### PR TITLE
Add support of Bearer Token and handle timestamp order mismatch issue

### DIFF
--- a/plugins/outputs/prometheus_remote_write/README.md
+++ b/plugins/outputs/prometheus_remote_write/README.md
@@ -10,6 +10,9 @@ This plugin sends metrics to services which speak the [Prometheus Remote Write](
   ## URL to send Prometheus remote write requests to.
   url = "http://localhost/push"
 
+  ## Optional Bearer token
+  # bearer_token = "bearer_token"
+
   ## HTTP asic auth credentials (optional).
   # basic_username = "username"
   # basic_password = "pa55w0rd"


### PR DESCRIPTION
ChangeLog - 
1. Add bearer Token support in remote write plugin
2. Sanitize the metrics to follow Prometheus format i.e having underscore in metrics.
3. Added sort functionality to handle timestamp mismatch issue happening in Cortex/Distributor.
### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
